### PR TITLE
fix: improve mobile side links usability and contact fit

### DIFF
--- a/app/components/RetroButton.tsx
+++ b/app/components/RetroButton.tsx
@@ -19,7 +19,7 @@ export default function RetroButton({ onClick, children, href, type = 'button' }
     background: '#FC4198',
     border: '3px solid #000000',
     padding: '20px',
-    width: 'min(120px, 100%)',
+    width: 'min(108px, 100%)',
     aspectRatio: '1 / 1',
     height: 'auto',
     minWidth: '0',

--- a/app/components/SocialLinks.tsx
+++ b/app/components/SocialLinks.tsx
@@ -21,53 +21,57 @@ const SocialLinks = ({ className = "" }: SocialLinksProps) => {
     window.open('https://github.com/Yatal42', '_blank');
   };
 
+  const containerStyle = { width: '56px', height: '420px' };
+
   return (
-    <div className={`relative ${className}`} style={{ width: '52px', height: '400px' }} id="social-links-container">
-      {/* Original SVG as background */}
+    <div className={`relative ${className}`} style={containerStyle} id="social-links-container">
       <img 
         src="/assets/side-icons.svg" 
         alt="Social Links" 
         className="w-full h-full opacity-90 pointer-events-none"
-        style={{ width: '52px', height: '400px', objectFit: 'contain' }}
+        style={{ width: '56px', height: '420px', objectFit: 'contain' }}
       />
-      
-      {/* CV - Invisible clickable area on CV text (top section) */}
-      <div
+
+      <button
+        type="button"
         onClick={handleCVClick}
-        className="absolute cursor-pointer"
+        className="social-link-hit-area"
         style={{ 
-          top: '140px',
-          left: '8px',
-          width: '36px',
-          height: '25px'
+          top: '31%',
+          left: '8%',
+          width: '84%',
+          height: '14%'
         }}
         title="Download CV"
+        aria-label="Download CV"
       />
-      
-      {/* GitHub - Invisible clickable area on GitHub icon (middle section) */}
-      <div
+
+      <button
+        type="button"
         onClick={handleGitHubClick}
-        className="absolute cursor-pointer"
+        className="social-link-hit-area"
         style={{ 
-          top: '185px',
-          left: '5px',
-          width: '42px',
-          height: '35px'
+          top: '43.5%',
+          left: '8%',
+          width: '84%',
+          height: '14%'
         }}
         title="Visit GitHub Profile"
+        aria-label="Visit GitHub Profile"
       />
-      
-      {/* LinkedIn - Invisible clickable area on LinkedIn icon (bottom section) */}
-      <div
+
+      <button
+        type="button"
         onClick={handleLinkedInClick}
-        className="absolute cursor-pointer"
+        className="social-link-hit-area"
         style={{ 
-          top: '230px',
-          left: '5px',
-          width: '42px',
-          height: '45px'
+          top: '56%',
+          left: '8%',
+          width: '84%',
+          height: '16%'
         }}
         title="Visit LinkedIn Profile"
+        aria-label="Visit LinkedIn Profile"
       />
     </div>
   );

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -48,7 +48,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <div className="retro-theme min-h-screen">
           <StarfieldBackground />
           <RetroNavbar />
-          <div className="fixed right-4 top-1/2 transform -translate-y-1/2 z-40">
+          <div className="social-links-wrapper fixed right-4 top-1/2 transform -translate-y-1/2 z-40">
             <SocialLinks className="flex-col gap-4" />
           </div>
           {children}

--- a/app/styles/retro.css
+++ b/app/styles/retro.css
@@ -134,6 +134,19 @@
   display: none;
 }
 
+.social-link-hit-area {
+  all: unset;
+  box-sizing: border-box;
+  position: absolute;
+  cursor: pointer;
+  display: block;
+}
+
+.social-link-hit-area:focus-visible {
+  outline: 2px solid #00FF41;
+  outline-offset: 1px;
+}
+
 .retro-nav-item {
   background: none;
   border: none;
@@ -476,17 +489,18 @@
   }
   
   /* Make side social links smaller and reposition on mobile */
-  .fixed.right-4 {
-    right: 2px !important;
-    top: 20% !important;
-    transform: translateY(0) !important;
+  .social-links-wrapper {
+    position: fixed !important;
+    right: 8px !important;
+    top: 50% !important;
+    bottom: auto !important;
+    transform: translateY(-50%) !important;
+    z-index: 45;
   }
   
   #social-links-container {
-    width: 26px !important;
-    height: 200px !important;
-    transform: scale(0.5);
-    transform-origin: center;
+    width: 44px !important;
+    height: 330px !important;
   }
   
   .pixel-heading {
@@ -2013,9 +2027,9 @@ button.project-link {
 
   .contact-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: min(100%, 300px);
+    width: min(100%, 260px);
     max-width: none;
-    gap: 12px;
+    gap: 10px;
     padding: 8px 0;
   }
 
@@ -2032,6 +2046,13 @@ button.project-link {
   .contact-section {
     padding-top: 16px;
     padding-bottom: 38px;
+  }
+}
+
+@media (max-width: 420px) {
+  .contact-grid {
+    width: min(100%, 236px);
+    gap: 8px;
   }
 }
 


### PR DESCRIPTION
Increase touch target size for the floating social links on mobile while keeping the menu available throughout page scroll, and tighten contact grid sizing to prevent overflow on narrower devices.

Made-with: Cursor