### PR TITLE
fix(transcript): route YouTube fetch through app endpoint in production

### DIFF
--- a/app/components/transcript/YouTubeTab.tsx
+++ b/app/components/transcript/YouTubeTab.tsx
@@ -40,7 +40,7 @@ export default function YouTubeTab({ onResult, setStatus }: Props) {
     setStatus({ kind: "info", message: "Downloading transcript..." });
     setLoading(true);
     try {
-      const res = await fetch(`/api/youtube-transcript?v=${encodeURIComponent(id)}`);
+      const res = await fetch(`/transcript-api/youtube-transcript?v=${encodeURIComponent(id)}`);
       const data = await res.json();
       if (!res.ok) {
         const messages: Record<string, string> = {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -4,4 +4,5 @@ export default [
   index("routes/home.tsx"),
   route("transcript", "routes/transcript.tsx"),
   route("api/youtube-transcript", "routes/api.youtube-transcript.ts"),
+  route("transcript-api/youtube-transcript", "routes/transcript-api.youtube-transcript.ts"),
 ] satisfies RouteConfig;

--- a/app/routes/transcript-api.youtube-transcript.ts
+++ b/app/routes/transcript-api.youtube-transcript.ts
@@ -1,0 +1,1 @@
+export { loader } from "./api.youtube-transcript";


### PR DESCRIPTION
Use a non-/api transcript endpoint for the YouTube tab and map it to the existing loader so production no longer hits the failing Python function path.